### PR TITLE
feat(admission): add visit creation notification after patient admission

### DIFF
--- a/src/api/patient-admission.resource.ts
+++ b/src/api/patient-admission.resource.ts
@@ -400,3 +400,30 @@ export const closeGlobalBill = async (globalBillId: string): Promise<any> => {
     throw error;
   }
 };
+
+/**
+ * Fetches patient visits within a specified date range
+ * @param patientUuid - The patient's UUID
+ * @param fromDate - The start date to check for visits (optional)
+ * @param toDate - The end date to check for visits (optional)
+ * @returns Promise with patient visits data
+ */
+export const getPatientVisits = async (patientUuid: string, fromDate?: Date, toDate?: Date): Promise<any> => {
+  try {
+    let url = `${restBaseUrl}/visit?patient=${patientUuid}&includeInactive=false&v=full`;
+    
+    if (fromDate) {
+      url += `&fromStartDate=${fromDate.toISOString()}`;
+    }
+    
+    if (toDate) {
+      url += `&toStartDate=${toDate.toISOString()}`;
+    }
+    
+    const response = await openmrsFetch(url);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching patient visits:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Add new API function to fetch patient visits with date filtering
- Enhance PatientAdmissionForm to check for newly created visits
- Show success notification with visit type when visit is created
- Optimize API call to only retrieve active visits using includeInactive=false

This improves user experience by confirming when both global bill and 
visit have been successfully created for a patient admission.

## Screenshots

https://github.com/user-attachments/assets/d930bb00-a693-4202-8847-20a168d315ab

![image](https://github.com/user-attachments/assets/ea910748-8598-47af-9795-9317179575da)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
