### PR TITLE
fix: resolve NullPointerException in global bill creation and improve UX

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -882,7 +882,7 @@ export const createDirectGlobalBill = async (globalBillData: {
         insurancePolicy: {
           insurancePolicyId: globalBillData.insurancePolicyId,
         },
-        admissionType: globalBillData.admissionType,
+        admissionType: globalBillData.admissionType || 1,
       },
     };
 

--- a/src/api/patient-admission.resource.ts
+++ b/src/api/patient-admission.resource.ts
@@ -260,7 +260,7 @@ export const createDirectGlobalBill = async (data: any): Promise<any> => {
         insurancePolicy: {
           insurancePolicyId: data.insurancePolicyId,
         },
-        admissionType: data.admissionType,
+        admissionType: data.admissionType || 1,
       },
     };
 

--- a/src/visit-attributes/patient-admission-form.component.tsx
+++ b/src/visit-attributes/patient-admission-form.component.tsx
@@ -95,7 +95,7 @@ const PatientAdmissionForm: React.FC<PatientAdmissionFormProps> = ({
       isAdmitted: false,
       admissionDate: new Date(),
       diseaseType: '',
-      admissionType: '',
+      admissionType: '1', 
     },
   });
 
@@ -344,7 +344,7 @@ const PatientAdmissionForm: React.FC<PatientAdmissionFormProps> = ({
           return;
         }
 
-        const admissionTypeNumber = parseInt(data.admissionType);
+        const admissionTypeNumber = parseInt(data.admissionType) || 1;
         const result = await createAdmissionWithGlobalBill({
           patientUuid: patientUuid,
           isAdmitted: data.isAdmitted,

--- a/src/visit-attributes/visit-form-admission-section.component.tsx
+++ b/src/visit-attributes/visit-form-admission-section.component.tsx
@@ -95,7 +95,7 @@ const VisitFormAdmissionSection: React.FC<VisitFormAdmissionSectionProps> = ({
       isAdmitted: false,
       admissionDate: new Date(),
       diseaseType: '',
-      admissionType: '',
+      admissionType: '1',
     },
   });
 
@@ -341,7 +341,7 @@ const VisitFormAdmissionSection: React.FC<VisitFormAdmissionSectionProps> = ({
           });
         }
 
-        const admissionTypeNumber = parseInt(data.admissionType);
+        const admissionTypeNumber = parseInt(data.admissionType) || 1;
         const result = await createAdmissionWithGlobalBill({
           patientUuid: patientUuid,
           isAdmitted: data.isAdmitted,
@@ -351,6 +351,12 @@ const VisitFormAdmissionSection: React.FC<VisitFormAdmissionSectionProps> = ({
           insuranceCardNumber: data.insuranceCardNumber,
           insurancePolicyId: insurancePolicyId,
           insuranceId: selectedInsurance?.insuranceId || 1,
+        });
+
+        showSnackbar({
+          title: 'Global Bill',
+          subtitle: 'Global bill has been created successfully',
+          kind: 'success',
         });
 
         setExtraVisitInfo({


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This fix prevents null admissionType in global bill creation

- Add default admissionType fallbacks across API and form layers
- Include success snackbar in visit form admission section

Fixes issue where empty admissionType caused backend BillingServiceAdvice to fail

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
