### PR TITLE
feat: enhance billing reports with improved UI and data handling

### DIFF
--- a/src/api/billing.ts
+++ b/src/api/billing.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { formatToYMD } from '../billing-reports/utils/download-utils';
 import { errorHandler, commonErrorMessages } from '../utils/error-handler';
@@ -220,6 +220,25 @@ export interface Insurance {
   }>;
 }
 
+export interface User {
+  uuid: string;
+  display: string;
+  username: string;
+  person: {
+    uuid: string;
+    display: string;
+  };
+  links: Array<{
+    rel: string;
+    uri: string;
+    resourceAlias: string;
+  }>;
+}
+
+export interface UserResponse {
+  results: Array<User>;
+}
+
 export interface InsuranceResponse {
   results: Array<Insurance>;
 }
@@ -236,6 +255,23 @@ export const getInsurances = async (): Promise<Array<Insurance>> => {
         return response.data.results;
       },
       { component: 'billing-api', action: 'getInsurances' },
+      commonErrorMessages.fetchError,
+    ) || []
+  );
+};
+
+/**
+ * Fetches all users/providers who can be collectors
+ * @returns Promise containing array of users
+ */
+export const getUsers = async (): Promise<Array<User>> => {
+  return (
+    errorHandler.wrapAsync(
+      async () => {
+        const response = await openmrsFetch<UserResponse>(`${restBaseUrl}/user?v=default`);
+        return response.data.results;
+      },
+      { component: 'billing-api', action: 'getUsers' },
       commonErrorMessages.fetchError,
     ) || []
   );

--- a/src/billing-reports/billing-reports.scss
+++ b/src/billing-reports/billing-reports.scss
@@ -389,6 +389,78 @@
     justify-content: flex-end;
   }
 
+  // Enhanced expanded table styles here
+  .billingExpandedTableContainer {
+    padding: layout.$spacing-05;
+    background-color: colors.$gray-10;
+    border-radius: 4px;
+    margin: layout.$spacing-03;
+  }
+
+  .billingExpandedTableTitle {
+    @include type.type-style('heading-compact-01');
+    color: colors.$gray-70;
+    margin: 0 0 layout.$spacing-04 0;
+    font-weight: 600;
+  }
+
+  .billingExpandedDetailsTable {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: colors.$white-0;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+
+    tbody tr {
+      border-bottom: 1px solid colors.$gray-20;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &:nth-child(even) {
+        background-color: colors.$gray-10;
+      }
+
+      &:hover {
+        background-color: colors.$blue-10;
+      }
+    }
+
+    td {
+      padding: layout.$spacing-04;
+      vertical-align: top;
+      border-right: 1px solid colors.$gray-20;
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+  }
+
+  .billingExpandedDetailLabel {
+    @include type.type-style('body-compact-01');
+    font-weight: 600;
+    color: colors.$gray-70;
+    width: 25%;
+    min-width: 120px;
+    background-color: colors.$gray-10;
+  }
+
+  .billingExpandedDetailValue {
+    @include type.type-style('body-compact-01');
+    color: colors.$gray-100;
+    width: 25%;
+    word-break: break-word;
+    
+    // Special styling for amounts/numbers
+    &:matches([class*="amount"], [class*="due"], [class*="paid"]) {
+      font-weight: 500;
+      text-align: right;
+    }
+  }
+
   // RTL support - scoped to billing wrapper
   &[dir='rtl'] {
     .billingDateAndLocation {

--- a/src/billing-reports/report-filter-form.component.tsx
+++ b/src/billing-reports/report-filter-form.component.tsx
@@ -20,9 +20,17 @@ interface ReportFilterFormProps {
   fields: ReportFilterField[];
   onSearch: (formData: Record<string, any>) => void;
   insuranceOptions?: { label: string; value: number }[];
+  companyOptions?: { label: string; value: string }[];
+  collectorOptions?: { label: string; value: string }[];
 }
 
-const ReportFilterForm: React.FC<ReportFilterFormProps> = ({ fields, onSearch, insuranceOptions }) => {
+const ReportFilterForm: React.FC<ReportFilterFormProps> = ({
+  fields,
+  onSearch,
+  insuranceOptions,
+  companyOptions,
+  collectorOptions,
+}) => {
   const { t } = useTranslation();
   const [formData, setFormData] = React.useState({});
 
@@ -140,23 +148,27 @@ const ReportFilterForm: React.FC<ReportFilterFormProps> = ({ fields, onSearch, i
 
       case 'company':
         return (
-          <TextInput
+          <Dropdown
             id="company"
-            labelText={t('company', 'Company')}
-            placeholder={t('enterCompanyName', 'Enter company name')}
-            aria-label={t('company', 'Company')}
-            onChange={(e) => handleChange('company', e.target.value)}
+            titleText={t('company', 'Company')}
+            size="md"
+            label={t('select', 'Select')}
+            items={companyOptions || []}
+            itemToString={(item) => item?.label || ''}
+            onChange={({ selectedItem }) => handleChange('company', selectedItem?.value)}
           />
         );
 
       case 'collector':
         return (
-          <TextInput
+          <Dropdown
             id="collector"
-            labelText={t('collector', 'Collector')}
-            placeholder={t('enterUserName', 'Enter user name')}
-            aria-label={t('collector', 'Collector')}
-            onChange={(e) => handleChange('collector', e.target.value)}
+            titleText={t('collector', 'Collector')}
+            size="md"
+            label={t('select', 'Select')}
+            items={collectorOptions || []}
+            itemToString={(item) => item?.label || ''}
+            onChange={({ selectedItem }) => handleChange('collector', selectedItem?.value)}
           />
         );
 


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

- Fix consommation report insurance dropdown to use names instead of IDs
  * Backend expects insurance names (e.g., "mutuelle") not IDs for filtering
  * Updated dropdown to send correct parameter format to API

- Redesign expanded table view in consommation report for better readability
  * Replace cramped inline layout with organized table structure
  * Add proper rows and columns for financial details, status, and collector info
  * Implement hover effects and alternating row colors for better UX
  * Add section header "Additional Details" for clarity

- Add collector dropdown to payment refund report
  * Replace text input with searchable dropdown of system users
  * Fetch users from OpenMRS user API with error handling
  * Display user names but send usernames to backend for compatibility

- Add getUsers API function for fetching OpenMRS users/providers
  * Includes proper error handling and TypeScript interfaces
  * Reusable for other components requiring user selection

- Enhance CSS styling for expanded table components
  * Add professional styling with Carbon Design System patterns
  * Improve visual hierarchy and readability

## Screenshots
![image](https://github.com/user-attachments/assets/94de6791-a8fb-4148-8fb4-601dc31a9cf3)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
