### PR TITLE
refactor: remove patientBill from consommation payload and eliminate redundant API calls

### DIFF
--- a/src/api/billing/index.ts
+++ b/src/api/billing/index.ts
@@ -59,7 +59,7 @@ export {
 } from './insurance';
 
 // Payment operations
-export { getPatientBills, submitBillPayment, createSimplePatientBill, type PatientBillResponse } from './payments';
+export { getPatientBills, submitBillPayment, type PatientBillResponse } from './payments';
 
 // Global Bill operations
 export {


### PR DESCRIPTION


## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

- Eliminate createSimplePatientBill from consommation flow  
- Remove patientBill field from POST payload
- Backend now handles PatientBill/InsuranceBill/ThirdPartyBill creation atomically
- Update tests and remove unused imports

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
