### PR TITLE
feat: Add multi-insurance support with expired policy validation

### DIFF
--- a/src/bill-tabs/global-bill-search.component.tsx
+++ b/src/bill-tabs/global-bill-search.component.tsx
@@ -40,11 +40,11 @@ const GlobalBillSearch: React.FC = () => {
       }
 
       const result = await getGlobalBillByIdentifier(globalBillIdentifier);
-      
+
       if (!result?.results || result.results.length === 0) {
         setErrorMessage(t('noResults', 'No results found.'));
       } else {
-        const validResults = result.results.filter(item => item !== null);
+        const validResults = result.results.filter((item) => item !== null);
         if (validResults.length === 0) {
           setErrorMessage(t('noResults', 'No results found.'));
         } else {
@@ -64,7 +64,9 @@ const GlobalBillSearch: React.FC = () => {
   };
 
   const handleRowClick = (result) => {
-    navigate({ to: `${window.getOpenmrsSpaBase()}home/billing/invoice/${result.admission.insurancePolicy.insuranceCardNo}` });
+    navigate({
+      to: `${window.getOpenmrsSpaBase()}home/billing/invoice/${result.admission.insurancePolicy.insuranceCardNo}`,
+    });
   };
 
   const renderResultsTable = () => {
@@ -72,7 +74,7 @@ const GlobalBillSearch: React.FC = () => {
       return null;
     }
 
-    if (!searchResult || searchResult.length === 0 || searchResult.every(item => item === null)) {
+    if (!searchResult || searchResult.length === 0 || searchResult.every((item) => item === null)) {
       return (
         <div className={styles.filterEmptyState}>
           <Layer>
@@ -151,11 +153,7 @@ const GlobalBillSearch: React.FC = () => {
               onChange={(e) => setGlobalBillIdentifier(e.target.value)}
               size="lg"
             />
-            <Button
-              onClick={handleGlobalBillSearch}
-              disabled={isLoading}
-              kind="primary"
-            >
+            <Button onClick={handleGlobalBillSearch} disabled={isLoading} kind="primary">
               {isLoading ? t('searching', 'Searching...') : t('search', 'Search')}
             </Button>
           </div>

--- a/src/invoice/invoice-table.component.tsx
+++ b/src/invoice/invoice-table.component.tsx
@@ -69,6 +69,24 @@ const InvoiceTable: React.FC<InvoiceTableProps> = (props) => {
   const patientBillResponse = usePatientBill(patientUuid || '');
   const insuranceBillResponse = useInsuranceCardBill(insuranceCardNo || '');
 
+  React.useEffect(() => {
+    const handleGlobalBillCreated = (event: CustomEvent) => {
+      if (patientUuid && event.detail?.patientUuid === patientUuid) {
+        patientBillResponse.mutate();
+      }
+
+      if (insuranceCardNo && event.detail?.insuranceCardNumber === insuranceCardNo) {
+        insuranceBillResponse.mutate();
+      }
+    };
+
+    window.addEventListener('globalBillCreated', handleGlobalBillCreated as EventListener);
+
+    return () => {
+      window.removeEventListener('globalBillCreated', handleGlobalBillCreated as EventListener);
+    };
+  }, [patientUuid, insuranceCardNo, patientBillResponse, insuranceBillResponse]);
+
   const usePatientData = Boolean(patientUuid);
   const useInsuranceData = Boolean(insuranceCardNo) && !usePatientData;
 


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

- Allow users to select specific insurance when multiple policies exist
- Create separate global bills for different insurance policies  
- Validate and prevent selection of expired insurance policies
- Add visual indicators for expired policies and existing bills
- Fix SWR cache invalidation for immediate UI updates

## Screenshots

https://github.com/user-attachments/assets/fc3e9319-6f4c-4d4c-b87d-fd8ac338236d


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
