### PR TITLE
Fix consommation items auto-reload and table layout responsiveness

### DIFF
--- a/src/consommation/embedded-consommations-list.component.tsx
+++ b/src/consommation/embedded-consommations-list.component.tsx
@@ -450,6 +450,20 @@ const EmbeddedConsommationsList = forwardRef<any, EmbeddedConsommationsListProps
       fetchConsommations();
     }, [fetchConsommations, cleanupOldPaymentData]);
 
+    // Ensure expanded consommations auto-load their items after any refresh
+    useEffect(() => {
+      if (expandedConsommations.size === 0 || consommationsWithItems.length === 0) return;
+
+      consommationsWithItems.forEach((c) => {
+        const id = c.consommationId?.toString();
+        if (!id) return;
+        if (expandedConsommations.has(id) && !c.itemsLoaded && !c.isLoadingItems) {
+          // Re-fetch items for expanded panels that lost their loaded state after a refresh
+          loadConsommationItems(id);
+        }
+      });
+    }, [consommationsWithItems, expandedConsommations, loadConsommationItems]);
+
     // Refresh insurance rates for all consommations when global bill changes
     const refreshAllInsuranceRates = useCallback(async () => {
       if (consommationsWithItems.length === 0) return;

--- a/src/consommation/embedded-consommations-list.scss
+++ b/src/consommation/embedded-consommations-list.scss
@@ -150,12 +150,11 @@ $disabled-03: #8d8d8d !default;
 .itemsTable {
   width: 100% !important;
   max-width: 100% !important;
-  overflow-x: hidden;
+  overflow-x: hidden; // we’ll wrap content instead of scrolling
   background-color: #fff;
   border-radius: 4px;
   border: 1px solid #ececec;
-  margin: 0;                      
-  display: block;
+  margin: 0;
 }
 
 /* ---------- Actual table ---------- */
@@ -163,7 +162,7 @@ $disabled-03: #8d8d8d !default;
   width: 100% !important;
   max-width: 100% !important;
   border-collapse: collapse;
-  table-layout: fixed;
+  table-layout: auto;
   margin: 0 !important;
 
   th,
@@ -173,9 +172,9 @@ $disabled-03: #8d8d8d !default;
     border-bottom: 1px solid #e0e0e0;
     font-size: 0.825rem;
     line-height: 1.2;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
   }
 
   /* Header */
@@ -185,85 +184,17 @@ $disabled-03: #8d8d8d !default;
     color: #161616;
   }
 
+  /* Column alignment without forcing widths */
+  tbody td:nth-child(1) { text-align: center; width: 36px; }
+  tbody td:nth-last-child(6),
+  tbody td:nth-last-child(5),
+  tbody td:nth-last-child(4),
+  tbody td:nth-last-child(3) { text-align: right; }
+  tbody td:nth-last-child(2) { text-align: center; }
+
   /* Hover */
   tbody tr:hover {
     background-color: #f8f9fa;
-  }
-
-  th:nth-child(1),
-  td:nth-child(1) {
-    width: 50px !important;
-    max-width: 50px !important;
-    text-align: center;
-  }
-
-  th:nth-child(2),
-  td:nth-child(2) {
-    width: 130px !important;
-    max-width: 130px !important;
-  }
-
-  th:nth-child(3),
-  td:nth-child(3) {
-    width: auto !important;
-    max-width: none !important;
-    min-width: 300px !important;
-  }
-
-  /* Qty - wider for better alignment and readability */
-  th:nth-last-child(8),
-  td:nth-last-child(8) {
-    width: 80px !important;
-    max-width: 80px !important;
-    text-align: center !important;
-  }
-
-  /* Unit Price - wider for better number display */
-  th:nth-last-child(7),
-  td:nth-last-child(7) {
-    width: 130px !important;
-    max-width: 130px !important;
-    text-align: right !important;
-  }
-
-  /* Total - wider for better number display */
-  th:nth-last-child(6),
-  td:nth-last-child(6) {
-    width: 130px !important;
-    max-width: 130px !important;
-    text-align: right !important;
-  }
-
-  /* Insurance - wider for better number display */
-  th:nth-last-child(5),
-  td:nth-last-child(5) {
-    width: 140px !important;
-    max-width: 140px !important;
-    text-align: right !important;
-  }
-
-  /* Patient - wider for better number display */
-  th:nth-last-child(4),
-  td:nth-last-child(4) {
-    width: 140px !important;
-    max-width: 140px !important;
-    text-align: right !important;
-  }
-
-  /* Paid - wider for better number display */
-  th:nth-last-child(3),
-  td:nth-last-child(3) {
-    width: 130px !important;
-    max-width: 130px !important;
-    text-align: right !important;
-  }
-
-  /* Status - wider for better badge display */
-  th:nth-last-child(2),
-  td:nth-last-child(2) {
-    width: 120px !important;
-    max-width: 120px !important;
-    text-align: center !important;
   }
 
   /* Edge padding trims to prevent overflow caused by cell padding */
@@ -285,9 +216,10 @@ $disabled-03: #8d8d8d !default;
 
 /* Item name clamp */
 .itemNameCell {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  word-break: break-word;
 }
 
 /* Status tag baseline */
@@ -387,6 +319,7 @@ $disabled-03: #8d8d8d !default;
     td {
       padding: 0.5rem 0.25rem;
       font-size: 0.75rem;
+      white-space: normal;
     }
   }
 }

--- a/src/payment-form/payment-form.component.tsx
+++ b/src/payment-form/payment-form.component.tsx
@@ -641,13 +641,9 @@ const PaymentForm: React.FC<PaymentFormProps> = ({
         setPaymentData(receiptPaymentData);
         setGroupedConsommationData(receiptGrouped);
         setPaidItems(allPaidItems);
+        // Do NOT refresh parent or close modal immediately; show success view with Print Receipt.
+        // Parent refresh is triggered only when the user closes the modal (see handleCloseModal).
         setPaymentSuccess(true);
-
-        try {
-          onSuccess();
-        } catch {
-          /* no-op */
-        }
 
         showToast({
           title: t('paymentSuccess', 'Payment Successful'),


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

- Added useEffect hook to auto-reload items for expanded consommations
  after refresh, preventing "Click to load items…" from persisting.
- Updated embedded-consommations-list.scss:
  - Switched table layout from fixed to auto for better responsiveness.
  - Removed hardcoded column widths and nowrap rules.
  - Allowed wrapping/word-break on long item names.
  - Right/center aligned numeric/status columns without forcing widths.
- Ensured item rows now stretch to fit accordion width and avoid overflow.

## Screenshots
Before:
<img width="4814" height="2300" alt="image" src="https://github.com/user-attachments/assets/5581d317-2025-41ea-b1fd-601be52b2f19" />


After:
<img width="5040" height="2638" alt="image" src="https://github.com/user-attachments/assets/8860e60e-7655-4f7f-91e3-23269ff2a233" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
